### PR TITLE
Remove colors in CI mode and unicode bullet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.1.2 (unreleased)
+
+- Removed unicode bullet point dron output.
+- Removed colors from CI output.
+
 ## v1.1.1
 
 - Fixed leading newlines not being removed in one go.

--- a/src/unbeheader/headers.py
+++ b/src/unbeheader/headers.py
@@ -74,10 +74,10 @@ def _do_update_header(file_path: Path, config: dict, regex: Pattern[str], commen
         return False
     # Print header update results
     if found:
-        msg = 'Incorrect header in %{white!}{}' if ci else 'Updating header in %{white!}{}'
+        msg = 'Incorrect header in {}' if ci else cformat('Updating header in %{white!}{}')
     else:
-        msg = 'Missing header in %{white!}{}' if ci else 'Adding header in %{white!}{}'
-    print(f'· {cformat(msg).format(os.path.relpath(file_path))}')
+        msg = 'Missing header in {}' if ci else cformat('Adding header in %{white!}{}')
+    print(msg.format(os.path.relpath(file_path)))
     # Write the updated file to disk
     if not ci:
         file_path.write_text(content)


### PR DESCRIPTION
When using a GitHub actions error matcher, the colors screw up the filename matching, and the bullet point simply doesn't look good.