### PR TITLE
Make CI workflows simpler

### DIFF
--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -11,29 +11,7 @@ on:
       - stable
 
 jobs:
-  setup:
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v3
-      - name: Install poetry
-        run: |
-          pipx install poetry
-      - name: Set up Python
-        id: python
-        if: steps.cache.outputs.cache-hit != 'true'
-        uses: actions/setup-python@v4
-        with:
-          # TODO: Remove explicit Python version once bug with .python-version file is solved
-          #       https://github.com/actions/setup-python/issues/734
-          python-version: '3.11'
-          cache: 'poetry'
-      - name: Install dependencies
-        if: steps.python.outputs.cache-hit != 'true'
-        run: |
-          poetry install --no-root
-
   lint:
-    needs: setup
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
@@ -48,7 +26,7 @@ jobs:
           #       https://github.com/actions/setup-python/issues/734
           python-version: '3.11'
           cache: 'poetry'
-      - name: Install dependencies
+      - name: Install package
         run: |
           poetry install
       - name: Run tests

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -11,31 +11,7 @@ on:
       - stable
 
 jobs:
-  setup:
-    runs-on: ubuntu-22.04
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ['3.9', '3.10', '3.11']
-    steps:
-      - uses: actions/checkout@v3
-      - name: Install poetry
-        run: |
-          pipx install poetry
-      - name: Set up Python
-        id: python
-        if: steps.cache.outputs.cache-hit != 'true'
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: 'poetry'
-      - name: Install dependencies
-        if: steps.python.outputs.cache-hit != 'true'
-        run: |
-          poetry install --no-root
-
   test:
-    needs: setup
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false


### PR DESCRIPTION
We don't gain anything anymore by having a `setup` step in the workflows. The original idea is that the `setup` step caches the virtualenv generated by `poetry install --no-root`, which was common in the `linting` and `testing` workflows. They both require to run now `poetry install`.

The benefit may haven even been negative before, since our dependencies are not too heavy nor we change them too often. The overhead of having to run an additional step with `actions/checkout@v3` and `actions/setup-python@v4` is likely higher (didn't check) than the any time we may be saving from caching.

This PR simplifies the workflows, making them more maintainable, caching instead the entire virtualenv and possibly reducing the time CI takes to run.

---

Workflows take half the time with the changes in this PR.